### PR TITLE
Add basic support for view-only user access

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 
 if [ -f "requirements.txt" ]; then
     if [ ! -d "venv" ]; then
-        virtualenv venv
+        virtualenv -p /usr/bin/python2.7 venv
         echo active venv
         source venv/bin/activate
         # sudo apt-get install python-dev

--- a/gomatic/gocd/pipelines.py
+++ b/gomatic/gocd/pipelines.py
@@ -178,6 +178,41 @@ class Job(CommonEqualityMixin):
         return result
 
 
+class User(CommonEqualityMixin):
+    def __init__(self, element):
+        self.element = element
+
+    @property
+    def username(self):
+        return self.element.text
+
+
+class ViewAuthorization(CommonEqualityMixin):
+    def __init__(self, element):
+        self.element = element
+
+    @property
+    def users(self):
+        return [User(e) for e in self.element.findall('user')]
+
+    def add_user(self, username):
+        Ensurance(self.element).ensure_child_with_text('user', username)
+        return self
+
+
+class Authorization(CommonEqualityMixin):
+    def __init__(self, element):
+        self.element = element
+
+    @property
+    def view(self):
+        return ViewAuthorization(self.element.find('view'))
+
+    def ensure_view(self):
+        view_element = Ensurance(self.element).ensure_child('view').element
+        return ViewAuthorization(view_element)
+
+
 class Stage(CommonEqualityMixin):
     def __init__(self, element):
         self.element = element
@@ -642,6 +677,10 @@ class PipelineGroup(CommonEqualityMixin):
         return self.__configurator.templates
 
     @property
+    def authorization(self):
+        return Authorization(self.element.find('authorization'))
+
+    @property
     def pipelines(self):
         return [Pipeline(e, self) for e in self.element.findall('pipeline')]
 
@@ -656,6 +695,10 @@ class PipelineGroup(CommonEqualityMixin):
             return self._matching_pipelines(name)[0]
         else:
             raise RuntimeError('Cannot find pipeline with name "%s" in %s' % (name, self.pipelines))
+
+    def ensure_authorization(self):
+        authorization_element = Ensurance(self.element).ensure_child('authorization').element
+        return Authorization(authorization_element)
 
     def ensure_pipeline(self, name):
         pipeline_element = Ensurance(self.element).ensure_child_with_attribute('pipeline', 'name', name).element

--- a/gomatic/xml_operations.py
+++ b/gomatic/xml_operations.py
@@ -16,6 +16,15 @@ class Ensurance(object):
         else:
             return Ensurance(child)
 
+    def ensure_child_with_text(self, name, text):
+        matching_elements = [e for e in self.element.findall(name) if e.text == text]
+        if len(matching_elements) == 0:
+            new_element = ET.fromstring('<%s>%s</%s>' % (name, text, name))
+            self.element.append(new_element)
+            return Ensurance(new_element)
+        else:
+            return Ensurance(matching_elements[0])
+
     def ensure_child_with_attribute(self, name, attribute_name, attribute_value):
         matching_elements = [e for e in self.element.findall(name) if e.attrib[attribute_name] == attribute_value]
         if len(matching_elements) == 0:

--- a/tests/go_cd_configurator_test.py
+++ b/tests/go_cd_configurator_test.py
@@ -1058,6 +1058,13 @@ class TestPipelineGroup(unittest.TestCase):
         pipeline_group = self._pipeline_group_from_config()
         self.assertEquals(2, len(pipeline_group.pipelines))
 
+    def test_can_authorize_read_only_users(self):
+        pipeline_group = self._pipeline_group_from_config()
+        pipeline_group.ensure_authorization().ensure_view().add_user('user1').add_user('user2')
+        self.assertEquals(2, len(pipeline_group.authorization.view.users))
+        self.assertEquals('user1', pipeline_group.authorization.view.users[0].username)
+        self.assertEquals('user2', pipeline_group.authorization.view.users[1].username)
+
     def test_can_add_pipeline(self):
         configurator = GoCdConfigurator(empty_config())
         pipeline_group = configurator.ensure_pipeline_group("new_group")


### PR DESCRIPTION
We have to create view-only users for certain pipeline groups so that we are able to give restricted access to e.g. dashboard user accounts.

This small patch allows us doing so and should lay the foundation for further user management from gomatic. Thanks to @pellepelster for awesome pairing on this pull request.