### PR TITLE
Force python version to 2.7

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 
 if [ -f "requirements.txt" ]; then
     if [ ! -d "venv" ]; then
-        virtualenv venv
+        virtualenv -p /usr/bin/python2.7 venv
         echo active venv
         source venv/bin/activate
         # sudo apt-get install python-dev


### PR DESCRIPTION
On many Linux machines, python3 is the default python executable nowadays.

By setting the version explicitly, this script works reliably on any
distribution.

Thanks to @pellepelster for awesome pairing again!