### PR TITLE
more authorization for pipeline groups (operate and admins)

### DIFF
--- a/gomatic/gocd/authorization.py
+++ b/gomatic/gocd/authorization.py
@@ -1,0 +1,73 @@
+from gomatic.mixins import CommonEqualityMixin
+from gomatic.xml_operations import Ensurance, PossiblyMissingElement
+
+class User(CommonEqualityMixin):
+    def __init__(self, element):
+        self.element = element
+
+    @property
+    def username(self):
+        return self.element.text
+
+
+class Role(CommonEqualityMixin):
+    def __init__(self, element):
+        self.element = element
+
+    @property
+    def name(self):
+        return self.element.text
+
+
+class InnerAuthorization(CommonEqualityMixin):
+    def __init__(self, element):
+        self.element = element
+
+    @property
+    def users(self):
+        return [User(e) for e in self.element.findall('user')]
+
+    @property
+    def roles(self):
+        return [Role(e) for e in self.element.findall('role')]
+
+    def add_user(self, username):
+        Ensurance(self.element).ensure_child_with_text('user', username)
+        return self
+
+    def add_role(self, role):
+        Ensurance(self.element).ensure_child_with_text('role', role)
+        return self
+
+
+class Authorization(CommonEqualityMixin):
+    def __init__(self, element):
+        self.element = element
+
+    @property
+    def view(self):
+        return InnerAuthorization(self.element.find('view'))
+
+    @property
+    def operate(self):
+        return InnerAuthorization(self.element.find('operate'))
+
+    @property
+    def admins(self):
+        return InnerAuthorization(self.element.find('admins'))
+
+    def ensure_view(self):
+        view_element = Ensurance(self.element).ensure_child('view').element
+        return InnerAuthorization(view_element)
+
+    def ensure_operate(self):
+        view_element = Ensurance(self.element).ensure_child('operate').element
+        return InnerAuthorization(view_element)
+
+    def ensure_admins(self):
+        view_element = Ensurance(self.element).ensure_child('admins').element
+        return InnerAuthorization(view_element)
+
+    def make_empty(self):
+        PossiblyMissingElement(self.element).remove_all_children()
+

--- a/tests/go_cd_configurator_test.py
+++ b/tests/go_cd_configurator_test.py
@@ -1132,6 +1132,31 @@ class TestPipeline(unittest.TestCase):
         self.assertEqual("eca7f187-73c2-4f62-971a-d15233937256", pipeline.package_material.ref)
 
 
+class TestAuthorization(unittest.TestCase):
+    def setUp(self):
+        configurator = GoCdConfigurator(config('config-with-two-pipelines'))
+        self.pipeline_group = configurator.ensure_pipeline_group('g')
+
+    def test_can_authorize_users_and_roles_for_operate(self):
+        self.pipeline_group.ensure_authorization().ensure_operate().add_user('user1').add_role('role1')
+
+        self.assertEqual(self.pipeline_group.authorization.operate.users[0].username, 'user1')
+        self.assertEqual(self.pipeline_group.authorization.operate.roles[0].name, 'role1')
+
+    def test_can_authorize_users_and_roles_for_admins(self):
+        self.pipeline_group.ensure_authorization().ensure_admins().add_user('user1').add_role('role1')
+
+        self.assertEqual(self.pipeline_group.authorization.admins.users[0].username, 'user1')
+        self.assertEqual(self.pipeline_group.authorization.admins.roles[0].name, 'role1')
+
+    def test_can_ensure_replacement_of_authorization(self):
+        self.pipeline_group.ensure_authorization().ensure_admins().add_user('user1')
+        self.assertEqual(len(self.pipeline_group.authorization.admins.users), 1)
+
+        self.pipeline_group.ensure_replacement_of_authorization().ensure_admins().add_user('user2')
+        self.assertEqual(len(self.pipeline_group.authorization.admins.users), 1)
+
+
 class TestPipelineGroup(unittest.TestCase):
     def _pipeline_group_from_config(self):
         return GoCdConfigurator(config('config-with-two-pipelines')).ensure_pipeline_group('P.Group')

--- a/tests/go_cd_configurator_test.py
+++ b/tests/go_cd_configurator_test.py
@@ -510,6 +510,14 @@ class TestStages(unittest.TestCase):
         self.assertEqual(s, stage)
         self.assertEqual(True, stage.has_manual_approval)
 
+    def test_manual_approval_can_have_authorization(self):
+        stage = typical_pipeline().stages[0]
+        s = stage.set_has_manual_approval(authorize_users=['user1'], authorize_roles=['role1'])
+
+        self.assertEqual(True, stage.has_manual_approval)
+        self.assertEqual(['user1'], stage.authorized_users)
+        self.assertEqual(['role1'], stage.authorized_roles)
+
     def test_stages_have_fetch_materials_flag(self):
         stage = typical_pipeline().ensure_stage("build")
         self.assertEqual(True, stage.fetch_materials)


### PR DESCRIPTION
Adds the ability to define 'operate' and 'admin' in addition of 'view' that was already implemented.

Also adds the ability to authorize a particular manual approval for a stage. 