### PR TITLE
Allow to set the default job timeout

### DIFF
--- a/gomatic/go_cd_configurator.py
+++ b/gomatic/go_cd_configurator.py
@@ -91,6 +91,14 @@ class GoCdConfigurator(object):
         self.__server_element_ensurance().set('siteUrl', site_url)
 
     @property
+    def default_job_timeout(self):
+        return self.__server_decimal_attribute('jobTimeout')
+
+    @default_job_timeout.setter
+    def default_job_timeout(self, timeout_in_minutes):
+        self.__server_element_ensurance().set('jobTimeout', str(timeout_in_minutes))
+
+    @property
     def agent_auto_register_key(self):
         return self.__possibly_missing_server_element().attribute('agentAutoRegisterKey')
 

--- a/tests/go_cd_configurator_test.py
+++ b/tests/go_cd_configurator_test.py
@@ -1492,11 +1492,13 @@ class TestGoCdConfigurator(unittest.TestCase):
         configurator.agent_auto_register_key = "a_ci_server"
         configurator.purge_start = Decimal("44.0")
         configurator.purge_upto = Decimal("88.0")
+        configurator.default_job_timeout = 42
         self.assertEqual("/a/dir", configurator.artifacts_dir)
         self.assertEqual("http://1.2.3.4/", configurator.site_url)
         self.assertEqual("a_ci_server", configurator.agent_auto_register_key)
         self.assertEqual(Decimal("44.0"), configurator.purge_start)
         self.assertEqual(Decimal("88.0"), configurator.purge_upto)
+        self.assertEqual(Decimal("42"), configurator.default_job_timeout)
 
     def test_can_have_no_pipeline_groups(self):
         self.assertEqual(0, len(GoCdConfigurator(empty_config()).pipeline_groups))


### PR DESCRIPTION
Hey gomatic Team,

in some of our projects we have to set the default pipeline timeout quite regularly. This PR helps with that. Are the tests sufficient this way?

Cheers
@pellepelster, @fbernitt and @holderbaum