### PR TITLE
17.8/17.9 config repo fixes

### DIFF
--- a/gomatic/fake.py
+++ b/gomatic/fake.py
@@ -1,5 +1,5 @@
 import codecs
-
+import json
 
 empty_config_xml = """<?xml version="1.0" encoding="utf-8"?>
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="72">
@@ -12,12 +12,14 @@ class FakeResponse(object):
         self.text = text
         self.headers = {'x-cruise-config-md5': '42'}
         self.status_code = 200
-
+    def json(self):
+        return json.loads(self.text)
 
 class FakeHostRestClient(object):
-    def __init__(self, config_string, thing_to_recreate_itself=None):
+    def __init__(self, config_string, thing_to_recreate_itself=None, version="16.3.0"):
         self.config_string = config_string
         self.thing_to_recreate_itself = thing_to_recreate_itself
+        self.version = version
 
     def __repr__(self):
         if self.thing_to_recreate_itself is None:
@@ -30,6 +32,8 @@ class FakeHostRestClient(object):
         # what we want in a controlled way
         if path == "/go/admin/restful/configuration/file/GET/xml":
             return FakeResponse(self.config_string)
+        if path == "/go/api/version":
+            return FakeResponse('{{"version": "{}"}}'.format(self.version))
         raise RuntimeError("not expecting to be asked for anything else")
 
 

--- a/gomatic/fake.py
+++ b/gomatic/fake.py
@@ -6,6 +6,8 @@ empty_config_xml = """<?xml version="1.0" encoding="utf-8"?>
   <server artifactsdir="artifacts" commandRepositoryLocation="default" serverId="96eca4bf-210e-499f-9dc9-0cefdae38d0c" />
 </cruise>"""
 
+# This is the oldest version we currently support. Ideally we can make this more automagic in the future
+DEFAULT_VERSION='16.3.0'
 
 class FakeResponse(object):
     def __init__(self, text):
@@ -16,7 +18,8 @@ class FakeResponse(object):
         return json.loads(self.text)
 
 class FakeHostRestClient(object):
-    def __init__(self, config_string, thing_to_recreate_itself=None, version="16.3.0"):
+    def __init__(self, config_string, thing_to_recreate_itself=None, version=DEFAULT_VERSION):
+
         self.config_string = config_string
         self.thing_to_recreate_itself = thing_to_recreate_itself
         self.version = version

--- a/gomatic/go_cd_configurator.py
+++ b/gomatic/go_cd_configurator.py
@@ -291,7 +291,8 @@ class HostRestClient(object):
         return (self.__username, self.__password) if self.__username or self.__password else None
 
     def get(self, path):
-        result = requests.get(self.__path(path), auth=self.__auth(), verify=self.__verify_ssl)
+        header = {'Accept': 'application/vnd.go.cd.v1+json'}
+        result = requests.get(self.__path(path), auth=self.__auth(), verify=self.__verify_ssl, headers=header)
         count = 0
         while ((result.status_code == 503) or (result.status_code == 504)) and (count < 5):
             result = requests.get(self.__path(path))

--- a/gomatic/gocd/config_repos.py
+++ b/gomatic/gocd/config_repos.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+import uuid
 
 from distutils.version import LooseVersion
 
@@ -86,7 +87,7 @@ class ConfigRepos(CommonEqualityMixin):
                         configuration.items()))
         if has_id(self.__configurator.server_version):
             if not repo_id:
-                repo_id = url.replace(':', '').replace('/', '-')
+                repo_id = str(uuid.uuid4())
             attr_name = 'pluginId' if has_new_attr_name(self.__configurator.server_version) else 'plugin'
             element = ET.fromstring('<config-repo {5}="{0}" id="{4}"><{2} url="{1}" />{3}</config-repo>'.format(
                 plugin, url, cvs, configuration_xml_string, repo_id, attr_name))

--- a/tests/go_cd_configurator_test.py
+++ b/tests/go_cd_configurator_test.py
@@ -681,6 +681,17 @@ class TestConfigRepo(unittest.TestCase):
 
         self.assertEqual(len(self.configurator.config_repos.config_repo), 3)
 
+    def test_changes_attrs_for_new_server_versions(self):
+        configurator = GoCdConfigurator(FakeHostRestClient(empty_config_xml, version='17.9.0'))
+        configurator.ensure_config_repos().ensure_config_repo('git://url', 'yml.config.plugin', repo_id='myRepo')
+        self.assertEqual(configurator.config_repos.config_repo[0].element.get('pluginId'), 'yml.config.plugin')
+        self.assertEqual(configurator.config_repos.config_repo[0].plugin, 'yml.config.plugin')
+        self.assertEqual(configurator.config_repos.config_repo[0].repo_id, 'myRepo')
+
+    def test_handles_unspecified_id_for_migration(self):
+        configurator = GoCdConfigurator(FakeHostRestClient(empty_config_xml, version='17.8.0'))
+        configurator.ensure_config_repos().ensure_config_repo('git://url', 'yml.config.plugin')
+        self.assertEqual(configurator.config_repos.config_repo[0].repo_id, 'git--url')
 
 class TestPipeline(unittest.TestCase):
     def test_pipelines_have_names(self):

--- a/tests/go_cd_configurator_test.py
+++ b/tests/go_cd_configurator_test.py
@@ -691,7 +691,7 @@ class TestConfigRepo(unittest.TestCase):
     def test_handles_unspecified_id_for_migration(self):
         configurator = GoCdConfigurator(FakeHostRestClient(empty_config_xml, version='17.8.0'))
         configurator.ensure_config_repos().ensure_config_repo('git://url', 'yml.config.plugin')
-        self.assertEqual(configurator.config_repos.config_repo[0].repo_id, 'git--url')
+        self.assertIsNotNone(configurator.config_repos.config_repo[0].repo_id)
 
 class TestPipeline(unittest.TestCase):
     def test_pipelines_have_names(self):


### PR DESCRIPTION
Should now successfully handle both the addition of config repo IDs and the change to the plugin attribute name. Resolves #40 