### PR TITLE
adding support to encrypt values using GoCD API

### DIFF
--- a/gomatic/fake.py
+++ b/gomatic/fake.py
@@ -39,6 +39,12 @@ class FakeHostRestClient(object):
             return FakeResponse('{{"version": "{}"}}'.format(self.version))
         raise RuntimeError("not expecting to be asked for anything else")
 
+    def post(self, path, data, headers=None):
+        expected_headers = {'Accept': 'application/vnd.go.cd.v1+json', 'Content-Type': 'application/json'}
+        if path == "/go/api/admin/encrypt" and headers == expected_headers:
+            value = json.loads(data)['value']
+            return FakeResponse('{{"encrypted_value": "{}"}}'.format(value))
+        raise RuntimeError("given this garbage: {} {} {}".format(path, data, headers))
 
 def load_file(config_name):
     with codecs.open('test-data/' + config_name + '.xml', encoding='utf-8') as xml_file:

--- a/gomatic/go_cd_configurator.py
+++ b/gomatic/go_cd_configurator.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 import requests
 
 from gomatic.gocd.config_repos import ConfigRepos
+from gomatic.gocd.encryption import Encryption
 from gomatic.gocd.security import Security
 from gomatic.gocd.elastic import Elastic
 from gomatic.gocd.agents import Agent
@@ -150,6 +151,9 @@ class GoCdConfigurator(object):
     @property
     def config_repos(self):
         return ConfigRepos(self.__xml_root.find('config-repos'), self)
+
+    def encryption(self):
+        return Encryption(self.server_version, self.__host_rest_client)
 
     def ensure_pipeline_group(self, group_name):
         pipeline_group_element = Ensurance(self.__xml_root).ensure_child_with_attribute("pipelines", "group", group_name)
@@ -327,6 +331,7 @@ class HostRestClient(object):
                 raise RuntimeError("Could not post config to Go server (%s) [status code=%s]:\n%s" % (url, result.status_code, message))
             except ValueError:
                 raise RuntimeError("Could not post config to Go server (%s) [status code=%s] (and result was not json):\n%s" % (url, result.status_code, result))
+        return result
 
 
 def main(args):

--- a/gomatic/gocd/encryption.py
+++ b/gomatic/gocd/encryption.py
@@ -1,0 +1,23 @@
+from gomatic.mixins import CommonEqualityMixin
+from distutils.version import LooseVersion as Version
+
+API_PATH = '/go/api/admin/encrypt'
+ENDPOINT_INTRODUCED_VERSION = Version('17.1.0')
+
+class Encryption(CommonEqualityMixin):
+    def __init__(self, version, client):
+        self.version = version
+        self.client = client
+
+    def __supported(self):
+        return Version(self.version) >= ENDPOINT_INTRODUCED_VERSION
+
+    def encrypt(self, value):
+        if not self.__supported():
+            raise RuntimeError("Your server does not support the encrypt endpoint, which was introduced in 17.1")
+
+        headers = {'Accept': 'application/vnd.go.cd.v1+json',
+                   'Content-Type': 'application/json'}
+        data = '{{"value": "{}"}}'.format(value)
+        response = self.client.post(API_PATH, data, headers)
+        return response.json()['encrypted_value']

--- a/tests/go_cd_configurator_test.py
+++ b/tests/go_cd_configurator_test.py
@@ -2035,6 +2035,16 @@ job.add_task(ExecTask(['true']))
         """
         self.assertEqual(simplified(expected), simplified(actual))
 
+class TestEncryption(unittest.TestCase):
+    def test_gets_encryped_value_from_api_call(self):
+        configurator = GoCdConfigurator(FakeHostRestClient(empty_config_xml, version='17.1.0'))
+        # expected == input because the stub does ROT26 encryption
+        expected = 'aValue'
+        actual = configurator.encryption().encrypt(expected)
+        self.assertEqual(expected, actual)
+    def test_aborts_on_invalid_version(self):
+        configurator = GoCdConfigurator(FakeHostRestClient(empty_config_xml, version='16.12.0'))
+        self.assertRaises(RuntimeError, configurator.encryption().encrypt, 'aValue')
 
 class TestXmlFormatting(unittest.TestCase):
     def test_can_format_simple_xml(self):


### PR DESCRIPTION
This is not _ready_ per se, but want feedback sooner rather than later.

GoCD encrypts secure environment variables so they aren't stored in plain text in the config XML. Since 17.1.0 an [API endpoint](https://api.gocd.org/17.1.0/#encryption) has existed to allow users to encrypt values client side. By adding this to gomatic we can support users setting secure environment variables from their gomatic config. 