### PR TITLE
fix save_config_locally not working with python3

### DIFF
--- a/gomatic/go_cd_configurator.py
+++ b/gomatic/go_cd_configurator.py
@@ -245,8 +245,8 @@ class GoCdConfigurator(object):
         config_before = prettify(self.__initial_config)
         config_after = prettify(self.config)
         if save_config_locally:
-            open('config-before.xml', 'w').write(config_before.encode('utf-8'))
-            open('config-after.xml', 'w').write(config_after.encode('utf-8'))
+            open('config-before.xml', 'w').write(config_before)
+            open('config-after.xml', 'w').write(config_after)
 
             def has_kdiff3():
                 try:

--- a/tests/go_cd_configurator_test.py
+++ b/tests/go_cd_configurator_test.py
@@ -3,6 +3,7 @@
 
 import unittest
 import xml.etree.ElementTree as ET
+import os
 from decimal import Decimal
 from xml.dom.minidom import parseString
 
@@ -1451,6 +1452,12 @@ class TestGoCdConfigurator(unittest.TestCase):
         p.ensure_stage('moo').ensure_job('bar')
 
         self.assertTrue(configurator.has_changes)
+
+    def test_saves_local_config_files_if_flag_is_true(self):
+        configurator = GoCdConfigurator(config('config-with-two-pipeline-groups'))
+        configurator.save_updated_config(save_config_locally=True, dry_run=True)
+        self.assertTrue(os.path.exists('config-before.xml'))
+        self.assertTrue(os.path.exists('config-after.xml'))
 
     def test_keeps_schema_version(self):
         empty_config = FakeHostRestClient(empty_config_xml.replace('schemaVersion="72"', 'schemaVersion="73"'), "empty_config()")


### PR DESCRIPTION
#write method in python 3 not supporting bytes returned by config_after.encode('utf-8').