### PR TITLE
add the ability to configure run instance count under jobs settings

### DIFF
--- a/gomatic/gocd/pipelines.py
+++ b/gomatic/gocd/pipelines.py
@@ -84,6 +84,24 @@ class Job(CommonEqualityMixin, EnvironmentVariableMixin, ResourceMixin):
         self.elastic_profile_id = elastic_profile_id
         return self
 
+    @property
+    def has_run_instance_count(self):
+        return 'runInstanceCount' in self.element.attrib        
+
+    @property
+    def run_instance_count(self):            
+        if not self.has_run_instance_count:
+            raise RuntimeError("Job (%s) does not have runInstanceCount" % self)
+        return self.element.attrib['runInstanceCount']
+
+    @run_instance_count.setter
+    def run_instance_count(self, run_instance_count):
+        self.element.attrib['runInstanceCount'] = run_instance_count       
+
+    def set_run_instance_count(self, run_instance_count):
+        self.run_instance_count = run_instance_count
+        return self         
+
     def __get_gocd_version_string(self):
         if self.parent_stage is not None \
                 and self.parent_stage.parent_pipeline is not None \

--- a/test-data/config-with-typical-pipeline.xml
+++ b/test-data/config-with-typical-pipeline.xml
@@ -36,7 +36,7 @@
       </stage>
       <stage name="package">
         <jobs>
-          <job name="docker" elasticProfileId="docker.unit-test">
+          <job name="docker" elasticProfileId="docker.unit-test" runInstanceCount="2">
             <tasks>
               <exec command="docker">
                 <arg>build</arg>

--- a/tests/go_cd_configurator_test.py
+++ b/tests/go_cd_configurator_test.py
@@ -162,6 +162,28 @@ class TestJobs(unittest.TestCase):
         except RuntimeError:
             pass
 
+    def test_jobs_can_have_run_instance_count(self):
+        job = typical_pipeline().ensure_stage("package").ensure_job("docker")
+        self.assertEqual(True, job.has_run_instance_count)
+        self.assertEqual("2", job.run_instance_count)            
+
+    def test_can_set_run_instance_count(self):
+        job = empty_stage().ensure_job("j")
+        j = job.set_run_instance_count(2)
+        self.assertEqual(j, job)
+        self.assertEqual(True, job.has_run_instance_count)
+        self.assertEqual(2, job.run_instance_count)
+
+    def test_jobs_do_not_have_to_have_run_instance_count(self):
+        stages = typical_pipeline().stages
+        job = stages[0].jobs[0]
+        self.assertEqual(False, job.has_run_instance_count)
+        try:
+            run_instance_count = job.run_instance_count
+            self.fail("should have thrown exception")
+        except RuntimeError:
+            pass        
+
     def test_can_ensure_job_has_resource(self):
         stages = typical_pipeline().stages
         job = stages[0].jobs[0]


### PR DESCRIPTION
### What
Currently, GoCD allows jobs be played in parallel and under the jobs settings there is an option called runInstanceCount which basically defines how many instances will run the job in parallel.

The documentation can be found at https://docs.gocd.org/current/advanced_usage/admin_spawn_multiple_jobs.html

### Why
_Copied from the documentation:_

If you want to run multiple instances of the same job configuration you do not have to maintain multiple copies of same job config. You can specify how many instances of job you need & Go will take care of spawing the required number of job instances during scheduling.

This feature is particularly useful for test parallelization. It enables Go users to integrate with other test parallelization tools like TLB etc. to achieve distributed test execution with minimal configuration.

This PR is just to allow this implementation from Gomatic.