### PR TITLE
The attribute origin is not allowed to appear in element fetchartifact on versions under 18.2

### DIFF
--- a/gomatic/gocd/tasks.py
+++ b/gomatic/gocd/tasks.py
@@ -36,7 +36,7 @@ class AbstractTask(CommonEqualityMixin):
 
 
 class FetchArtifactTask(AbstractTask):
-    def __init__(self, pipeline, stage, job, src, dest=None, runif="passed", origin="gocd"):
+    def __init__(self, pipeline, stage, job, src, dest=None, runif="passed", origin=None):
         super(self.__class__, self).__init__(runif)
         self.__pipeline = pipeline
         self.__stage = stage
@@ -86,11 +86,15 @@ class FetchArtifactTask(AbstractTask):
         src_type, src_value = self.src.as_xml_type_and_value
         if self.__dest is None:
             new_element = ET.fromstring(
-                '<fetchartifact pipeline="%s" stage="%s" job="%s" origin="%s" %s="%s" />' % (self.__pipeline, self.__stage, self.__job, self.__origin, src_type, src_value))
+                '<fetchartifact pipeline="%s" stage="%s" job="%s" %s="%s" />' % (self.__pipeline, self.__stage, self.__job, src_type, src_value))
         else:
             new_element = ET.fromstring(
-                '<fetchartifact pipeline="%s" stage="%s" job="%s" origin="%s" %s="%s" dest="%s"/>' % (
-                    self.__pipeline, self.__stage, self.__job, self.__origin, src_type, src_value, self.__dest))
+                '<fetchartifact pipeline="%s" stage="%s" job="%s" %s="%s" dest="%s"/>' % (
+                    self.__pipeline, self.__stage, self.__job, src_type, src_value, self.__dest))
+        
+        if self.__origin is not None:
+            element.set('origin',self.__origin)
+        
         new_element.append(ET.fromstring('<runif status="%s" />' % self.runif))
 
         Ensurance(element).ensure_child("tasks").append(new_element)

--- a/test-data/cruise-config-18.3-and-above.xsd
+++ b/test-data/cruise-config-18.3-and-above.xsd
@@ -650,7 +650,7 @@
                 <xsd:attribute name="srcfile" type="filePathType"/>
                 <xsd:attribute name="dest" type="filePathType"/>
                 <xsd:attribute name="artifactId" type="xsd:string"/>
-                <xsd:attribute name="origin" use="required">
+                <xsd:attribute name="origin">
                     <xsd:simpleType>
                         <xsd:restriction base="xsd:string">
                             <xsd:enumeration value="gocd"/>


### PR DESCRIPTION
### What
The default value for the origin attribute has been set to None.
Also, the xsd schema has been updated removing the requirement.
And condiction was added in order to verify the nullable value.

### Why
Versions lower than 1.8.2 don't allow the origin attribute within fetchArtifact element. The changes made on  https://github.com/gocd-contrib/gomatic/commit/5274606037d3dff91c16952548a20351c9928b37 are breaking Gomatic due to **Attribute ‘origin’ is not allowed to appear in element ‘fetchartifact’.**

So, the changes are just to guarantee Gomatic to still work on GoCD as 1.8.2.