### PR TITLE
Adds back HTTP basic auth to GET requests.

### DIFF
--- a/gomatic/go_cd_configurator.py
+++ b/gomatic/go_cd_configurator.py
@@ -333,7 +333,7 @@ class HostRestClient(object):
         header = {'Accept': 'application/vnd.go.cd.v1+json'}
         if self.__access_token is not None:
             header["Authorization"] = "Bearer %s" % self.__access_token
-        result = requests.get(self.__path(path), verify=self.__verify_ssl, headers=header)
+        result = requests.get(self.__path(path), auth=self.__auth(), verify=self.__verify_ssl, headers=header)
         count = 0
         while ((result.status_code == 503) or (result.status_code == 504)) and (count < 5):
             result = requests.get(self.__path(path))


### PR DESCRIPTION
On the latest gomatic version the HTTP basic auth was removed from GET requests breaking it's backward compatibility. Maybe makes sense to add it back since we are still accepting it on POST requests.

Thanks! 